### PR TITLE
Add a ready event

### DIFF
--- a/app.js
+++ b/app.js
@@ -117,7 +117,12 @@ wss.on('connection', function connection(ws, req) {
 
                         // Add viewer to Redis list.
                         red.sadd(`stream:${channel}:viewers`, JSON.stringify(viewer));
-                        ws.send({"event":"ready","data": viewer});
+            
+                        // Send ready event.
+                        ws.send(JSON.stringify({
+                            'event': 'ready',
+                            'data': 'authorised successfully'
+                        }));
                     }).catch(error => {
                     console.log(error);
                     return ws.terminate();

--- a/app.js
+++ b/app.js
@@ -121,7 +121,7 @@ wss.on('connection', function connection(ws, req) {
                         // Send ready event.
                         ws.send(JSON.stringify({
                             'event': 'ready',
-                            'data': 'authorised successfully'
+                            'data': viewer
                         }));
                     }).catch(error => {
                     console.log(error);

--- a/app.js
+++ b/app.js
@@ -117,6 +117,7 @@ wss.on('connection', function connection(ws, req) {
 
                         // Add viewer to Redis list.
                         red.sadd(`stream:${channel}:viewers`, JSON.stringify(viewer));
+                        ws.send({"event":"ready","data": viewer});
                     }).catch(error => {
                     console.log(error);
                     return ws.terminate();


### PR DESCRIPTION
Add a 'ready' event to the chat server for users who are joining a channel to let them know when they have successfully connected to the server and can start sending messages.

Suggested by VoxtlJS